### PR TITLE
NUMA node aware allocator implemented using the PMR interface

### DIFF
--- a/cmake/DefineL3STERTestTarget.cmake
+++ b/cmake/DefineL3STERTestTarget.cmake
@@ -4,7 +4,8 @@ add_executable( L3STER_tests
                 ${L3STER_DIR}/tests/MathTests.cpp
                 ${L3STER_DIR}/tests/MeshTests.cpp
                 ${L3STER_DIR}/tests/QuadratureTests.cpp
-                ${L3STER_DIR}/tests/HwlocTests.cpp )
+                ${L3STER_DIR}/tests/HwlocTests.cpp
+                ${L3STER_DIR}/tests/NodeAllocationTests.cpp )
 
 set( L3STER_TESTS_DATA_PATH "${L3STER_DIR}/tests/data" CACHE STRING "Path to test data directory" )
 set( L3STER_N_NUMA_NODES 1 CACHE STRING "Number of NUMA nodes of current machine" )

--- a/include/numa/NodeGlobalResource.hpp
+++ b/include/numa/NodeGlobalResource.hpp
@@ -1,0 +1,71 @@
+#ifndef L3STER_NUMA_NODEGLOBAL_RESOURCE_HPP
+#define L3STER_NUMA_NODEGLOBAL_RESOURCE_HPP
+
+#include "numa/HwlocWrapper.hpp"
+
+#include <memory>
+#include <memory_resource>
+#include <unordered_map>
+
+namespace lstr
+{
+class NodeGlobalResource final : public std::pmr::memory_resource
+{
+public:
+    explicit NodeGlobalResource(HwlocWrapper* topo_ptr_, size_t node_) : topo_ptr{topo_ptr_}, node{node_} {}
+    NodeGlobalResource(const NodeGlobalResource&) = delete;
+    NodeGlobalResource(NodeGlobalResource&&)      = delete;
+    NodeGlobalResource& operator=(const NodeGlobalResource&) = delete;
+    NodeGlobalResource& operator=(NodeGlobalResource&&) = delete;
+    ~NodeGlobalResource() final                         = default;
+
+    [[nodiscard]] inline void* do_allocate(size_t bytes, size_t alignment) final;
+    inline void                do_deallocate(void* p, size_t bytes, size_t alignment) final;
+    [[nodiscard]] inline bool  do_is_equal(const memory_resource& other) const noexcept final;
+
+    HwlocWrapper*                           topo_ptr;
+    std::pmr::unsynchronized_pool_resource  internal_resource{};
+    std::pmr::unordered_map< void*, void* > alloc_map{&internal_resource};
+    size_t                                  node;
+};
+
+void* NodeGlobalResource::do_allocate(size_t bytes, size_t alignment)
+{
+    // Allocate
+    const size_t alloc_size     = bytes + alignment - 1;
+    void*        alloc_location = topo_ptr->allocateOnNode(alloc_size, node);
+    if (!alloc_location)
+        throw std::bad_alloc{};
+
+    // Align
+    size_t throwaway        = std::numeric_limits< size_t >::max();
+    void*  aligned_location = alloc_location;
+    std::align(alignment, alloc_size, aligned_location, throwaway); // guaranteed to succeed
+
+    // Pointer bookkeeping for deallocation
+    alloc_map[aligned_location] = alloc_location;
+
+    return aligned_location;
+}
+
+void NodeGlobalResource::do_deallocate(void* p, size_t bytes, size_t alignment)
+{
+    const auto it = alloc_map.find(p);
+    topo_ptr->free(it->second, bytes + alignment - 1);
+    alloc_map.erase(it);
+}
+
+bool NodeGlobalResource::do_is_equal(const std::pmr::memory_resource& other) const noexcept
+{
+    try
+    {
+        const auto& other_downcast = dynamic_cast< const NodeGlobalResource& >(other);
+        return other_downcast.topo_ptr == topo_ptr;
+    }
+    catch (const std::bad_cast&)
+    {
+        return false;
+    }
+}
+} // namespace lstr
+#endif // L3STER_NUMA_NODEGLOBAL_RESOURCE_HPP

--- a/tests/NodeAllocationTests.cpp
+++ b/tests/NodeAllocationTests.cpp
@@ -1,0 +1,25 @@
+#include "numa/NodeGlobalResource.hpp"
+
+#include "catch2/catch.hpp"
+#include <vector>
+
+TEST_CASE("Node allocation tests", "[hwloc]")
+{
+    lstr::HwlocWrapper       topo{};
+    lstr::NodeGlobalResource alloc{&topo, 0};
+    {
+        std::pmr::vector< double > v(&alloc);
+        v.push_back(3.14);
+        v.push_back(3.14);
+        CHECK(v.size() == 2);
+    }
+
+    constexpr size_t too_big_alloc = std::numeric_limits< size_t >::max() / 2 - 1;
+    CHECK_THROWS_AS(alloc.allocate(too_big_alloc), std::bad_alloc);
+
+    std::pmr::unsynchronized_pool_resource res;
+    CHECK_FALSE(alloc.is_equal(res));
+
+    lstr::NodeGlobalResource alloc2{&topo, 0};
+    CHECK(alloc.is_equal(alloc2));
+}


### PR DESCRIPTION
`NodeGlobalResource` allocates on the specified node, and can be used as an upstream resource for arena allocators. 