### PR TITLE
Codecov update

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,3 +21,4 @@ comment:
 
 ignore:
   - "**/*Test*.cpp"
+  - "build"

--- a/scripts/ci/Dockerfile.base
+++ b/scripts/ci/Dockerfile.base
@@ -5,7 +5,7 @@
 
 FROM archlinux:latest
 
-RUN pacman -Syu --noconfirm git python3 patch cmake gcc10 gcc10-fortran make gcovr shasum
+RUN pacman -Syu --noconfirm git python3 patch cmake gcc10 gcc10-fortran make gcovr
 RUN mkdir -p ~/.spack; \
     echo "packages:" > ~/.spack/packages.yaml && \
     echo "  cmake:" >> ~/.spack/packages.yaml && \

--- a/scripts/ci/Dockerfile.base
+++ b/scripts/ci/Dockerfile.base
@@ -5,7 +5,7 @@
 
 FROM archlinux:latest
 
-RUN pacman -Syu --noconfirm git python3 patch cmake gcc10 gcc10-fortran make gcovr
+RUN pacman -Syu --noconfirm git python3 patch cmake gcc10 gcc10-fortran make gcovr shasum
 RUN mkdir -p ~/.spack; \
     echo "packages:" > ~/.spack/packages.yaml && \
     echo "  cmake:" >> ~/.spack/packages.yaml && \

--- a/scripts/ci/entrypoint.sh
+++ b/scripts/ci/entrypoint.sh
@@ -20,7 +20,7 @@ if [ "$REPORT_COVERAGE" != "" ]; then
   curl -Os https://uploader.codecov.io/latest/codecov-linux.SHA256SUM || exit 1
   curl -Os https://uploader.codecov.io/latest/codecov-linux.SHA256SUM.sig || exit 1
   gpg --verify codecov-linux.SHA256SUM.sig codecov-linux.SHA256SUM || exit 1
-  shasum -a 256 -c codecov-linux.SHA256SUM || exit 1
+  sha1sum -a 256 -c codecov-linux.SHA256SUM || exit 1
   chmod +x codecov-linux
   ./codecov-linux -Z -X gcov || exit 1
 fi

--- a/scripts/ci/entrypoint.sh
+++ b/scripts/ci/entrypoint.sh
@@ -15,7 +15,12 @@ ctest --output-on-failure --repeat until-pass:2 --timeout 600 || exit 1
 if [ "$REPORT_COVERAGE" != "" ]; then
   chmod +x generate_coverage_report.sh
   ./generate_coverage_report.sh || exit 1
-  curl -s https://codecov.io/bash >codecov.sh || exit 1
-  chmod +x codecov.sh
-  ./codecov.sh -Z -X gcov || exit 1
+  curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import || exit 1
+  curl -Os https://uploader.codecov.io/latest/codecov-linux || exit 1
+  curl -Os https://uploader.codecov.io/latest/codecov-linux.SHA256SUM || exit 1
+  curl -Os https://uploader.codecov.io/latest/codecov-linux.SHA256SUM.sig || exit 1
+  gpg --verify codecov-linux.SHA256SUM.sig codecov-linux.SHA256SUM || exit 1
+  shasum -a 256 -c codecov-linux.SHA256SUM || exit 1
+  chmod +x codecov-linux
+  ./codecov-linux -Z -X gcov || exit 1
 fi

--- a/scripts/ci/entrypoint.sh
+++ b/scripts/ci/entrypoint.sh
@@ -20,7 +20,7 @@ if [ "$REPORT_COVERAGE" != "" ]; then
   curl -Os https://uploader.codecov.io/latest/codecov-linux.SHA256SUM || exit 1
   curl -Os https://uploader.codecov.io/latest/codecov-linux.SHA256SUM.sig || exit 1
   gpg --verify codecov-linux.SHA256SUM.sig codecov-linux.SHA256SUM || exit 1
-  sha1sum -a 256 -c codecov-linux.SHA256SUM || exit 1
+  sha256sum -c codecov-linux.SHA256SUM || exit 1
   chmod +x codecov-linux
   ./codecov-linux -Z -X gcov || exit 1
 fi


### PR DESCRIPTION
Codecov uploader has been updated to the newly released binary version. The old bash uploader is getting deprecated due to security concerns.