### PR TITLE
Gcc version proofing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: tests
-on: [ push, pull_request ]
+on: push
 env:
   DOCKER_BASE: "${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_IMAGE }}:latest"
   OMPI_ALLOW_RUN_AS_ROOT: 1

--- a/include/defs/Typedefs.h
+++ b/include/defs/Typedefs.h
@@ -8,6 +8,7 @@
 
 namespace lstr
 {
+using std::ptrdiff_t;
 using std::size_t;
 
 using val_t       = double;        // floating point value type

--- a/include/math/LagrangeInterpolation.hpp
+++ b/include/math/LagrangeInterpolation.hpp
@@ -20,21 +20,21 @@ requires(N > 1) constexpr Polynomial< T, N - 1 > lagrangeInterp(const std::array
     // meant for.
 
     std::array< T, N > lag_coefs{};
-    for (size_t i = 0; i < N; ++i)
+    for (auto i : std::views::iota(0, ptrdiff_t{N}))
     {
         std::array< T, N - 1 > roots;
         std::copy_n(begin(x), i, roots.begin());
         std::ranges::copy(x | std::views::drop(i + 1), begin(roots) + i);
         std::array< T, N > l_i{};
         l_i.front() = 1.;
-        for (auto j : std::views::iota(0u, N - 1))
+        for (auto j : std::views::iota(0, ptrdiff_t{N - 1}))
         {
-            for (size_t k = j + 1; k > 0; --k)
+            for (ptrdiff_t k = j + 1; k > 0; --k)
                 l_i[k] -= l_i[k - 1] * roots[j];
         }
         const PolynomialView root_poly{l_i};
         const T              s = y[i] / root_poly.evaluate(x[i]);
-        for (auto j : std::views::iota(0u, N))
+        for (auto j : std::views::iota(0, ptrdiff_t{N}))
             lag_coefs[j] += s * l_i[j];
     }
     return Polynomial{lag_coefs};

--- a/tests/MeshTests.cpp
+++ b/tests/MeshTests.cpp
@@ -363,7 +363,7 @@ TEST_CASE("Mesh conversion to higher order", "[mesh]")
         lstr::convertMeshToOrder< order >(part);
         CHECK(n_elements == part.getNElements());
         const auto validate_elorder = [&]< lstr::ElementTypes T, lstr::el_o_t O >(const lstr::Element< T, O >&) {
-            if constexpr (O != order)
+            if constexpr (O != 2)
                 throw std::logic_error{"Incorrect element order"};
         };
         CHECK_NOTHROW(part.cvisit(validate_elorder));
@@ -387,7 +387,7 @@ TEST_CASE("Mesh conversion to higher order", "[mesh]")
         const auto expected_n_nodes    = expected_edge_nodes * expected_edge_nodes * expected_edge_nodes;
         CHECK(part.getNodes().size() == expected_n_nodes);
         const auto validate_elorder = [&]< lstr::ElementTypes T, lstr::el_o_t O >(const lstr::Element< T, O >&) {
-            if constexpr (O != order)
+            if constexpr (O != 2)
                 throw std::logic_error{"Incorrect element order"};
         };
         CHECK_NOTHROW(part.cvisit(validate_elorder));


### PR DESCRIPTION
Avoided errors in gcc 10.1 (incorrect constexpr capture) and 11.1 (disallowed narrowing conversion in std::views::{drop, take}).