### PR TITLE
Matrix-free multi-RHS support

### DIFF
--- a/cmake/toolchains/Benchmarks.cmake
+++ b/cmake/toolchains/Benchmarks.cmake
@@ -1,3 +1,3 @@
 # Toolchain for static analysis using gcc
 set( CMAKE_CXX_COMPILER mpicxx )
-set( CMAKE_CXX_FLAGS_INIT "-march=native -mtune=native" )
+set( CMAKE_CXX_FLAGS_INIT "-march=native -mtune=native -Wno-interference-size" )

--- a/include/l3ster/algsys/ComputeValuesAtNodes.hpp
+++ b/include/l3ster/algsys/ComputeValuesAtNodes.hpp
@@ -416,14 +416,14 @@ void computeValuesAtNodes(const ResidualDomainKernel< Kernel, params >&     kern
             const auto& basis_at_nodes = basis::getBasisAtNodes< ET, EO >();
             const auto& node_locations = mesh::getNodeLocations< ET, EO >();
             const auto  node_vals      = field_access.getLocallyIndexed(el_nodes);
-            const auto  jacobi_gen     = map::getNatJacobiMatGenerator(element.data);
+            const auto  jacobi_gen     = map::getNatJacobiMatGenerator(element.getData());
             for (auto&& [node_ind, node] : el_nodes | std::views::enumerate)
             {
                 const auto& ref_coords    = node_locations[node_ind];
                 const auto& ref_ders      = basis_at_nodes.derivatives[node_ind];
                 const auto [phys_ders, _] = map::mapDomain< ET, EO >(jacobi_gen, ref_coords, ref_ders);
                 const auto ker_res        = evalKernel(
-                    kernel, ref_coords, basis_at_nodes.values[node_ind], phys_ders, node_vals, element.data, time);
+                    kernel, ref_coords, basis_at_nodes.values[node_ind], phys_ders, node_vals, element.getData(), time);
                 for (auto&& [dof_ind, dof] : detail::getNodeDofsAtInds(dof_map, dof_inds, node) | std::views::enumerate)
                     for (size_t rhs_ind = 0; rhs_ind != n_rhs; ++rhs_ind)
                     {

--- a/include/l3ster/comm/ImportExport.hpp
+++ b/include/l3ster/comm/ImportExport.hpp
@@ -82,7 +82,13 @@ class ImportExportBase
     static constexpr int   lo_mask    = -1 >> half_bits;
 
 public:
-    auto getContext() const { return m_context; }
+    auto                 getContext() const { return m_context; }
+    [[nodiscard]] size_t getNumVecs() const { return m_num_vecs; }
+    void                 setNumVecs(size_t num_vecs)
+    {
+        util::throwingAssert(num_vecs <= m_num_vecs_max);
+        m_num_vecs = num_vecs;
+    }
 
 protected:
     int makeTag(int tag) { return (tag & lo_mask) | std::bit_cast< int >(m_id << half_bits); }
@@ -92,6 +98,7 @@ protected:
     ImportExportBase(context_shared_ptr_t context, size_t num_vecs)
         : m_context{std::move(context)},
           m_num_vecs{num_vecs},
+          m_num_vecs_max{num_vecs},
           m_requests(num_vecs * m_context->getNumNbrs()),
           m_pack_buf(num_vecs * m_context->getOwnedInds().size()),
           m_max_owned{m_context->getOwnedInds().empty() ? -1 : std::ranges::max(m_context->getOwnedInds())},
@@ -103,6 +110,7 @@ protected:
 
     std::shared_ptr< const ImportExportContext > m_context{};
     size_t                                       m_num_vecs{};
+    size_t                                       m_num_vecs_max{};
     util::ArrayOwner< MpiComm::Request >         m_requests;
     util::ArrayOwner< Scalar >                   m_pack_buf;
     size_t                                       m_owned_stride{}, m_shared_stride{};

--- a/include/l3ster/comm/ImportExport.hpp
+++ b/include/l3ster/comm/ImportExport.hpp
@@ -91,7 +91,13 @@ public:
     }
 
 protected:
-    int makeTag(int tag) { return (tag & lo_mask) | std::bit_cast< int >(m_id << half_bits); }
+    int makeTag(int tag) const
+    {
+        const auto retval = (tag & lo_mask) | std::bit_cast< int >(m_id << half_bits);
+        util::throwingAssert(retval >= 0);
+        util::throwingAssert(retval < comm::getMaxMpiTag());
+        return retval;
+    }
 
     using context_shared_ptr_t = std::shared_ptr< const ImportExportContext >;
 

--- a/include/l3ster/comm/ImportExport.hpp
+++ b/include/l3ster/comm/ImportExport.hpp
@@ -77,9 +77,13 @@ class ImportExportBase
     using LocalIndex = local_dof_t;
 
     // Each import/export object has a unique ID, which is used to deconflict comms from different objects
-    inline static unsigned id_counter = 0;
-    static constexpr int   half_bits  = sizeof(int) * CHAR_BIT / 2;
-    static constexpr int   lo_mask    = -1 >> half_bits;
+    inline static unsigned short id_counter   = 1;
+    static constexpr size_t      tag_bits     = 12;
+    static constexpr size_t      id_bits      = 8;
+    static constexpr size_t      max_num_vecs = 1uz << tag_bits;
+    static constexpr int         int_bits     = sizeof(int) * CHAR_BIT;
+    static constexpr int         tag_mask     = -1u >> (int_bits - tag_bits);
+    static constexpr int         id_mask      = -1u >> (int_bits - id_bits);
 
 public:
     auto                 getContext() const { return m_context; }
@@ -91,13 +95,7 @@ public:
     }
 
 protected:
-    int makeTag(int tag) const
-    {
-        const auto retval = (tag & lo_mask) | std::bit_cast< int >(m_id << half_bits);
-        util::throwingAssert(retval >= 0);
-        util::throwingAssert(retval < comm::getMaxMpiTag());
-        return retval;
-    }
+    [[nodiscard]] int makeTag(int tag) const { return (tag & tag_mask) | std::bit_cast< int >(m_id); }
 
     using context_shared_ptr_t = std::shared_ptr< const ImportExportContext >;
 
@@ -108,8 +106,11 @@ protected:
           m_requests(num_vecs * m_context->getNumNbrs()),
           m_pack_buf(num_vecs * m_context->getOwnedInds().size()),
           m_max_owned{m_context->getOwnedInds().empty() ? -1 : std::ranges::max(m_context->getOwnedInds())},
-          m_id{id_counter++ & (-1u >> 1)} // make sure the highest bit is always 0
-    {}
+          m_id{(id_mask & id_counter++) << tag_bits}
+    {
+        util::throwingAssert(num_vecs < max_num_vecs);
+        util::throwingAssert(makeTag(-1) <= getMaxMpiTag(), "MPI_TAG_UB value too low");
+    }
 
     bool isOwnedSizeSufficient(size_t size) const;
     bool isSharedSizeSufficient(size_t size) const;
@@ -121,7 +122,7 @@ protected:
     util::ArrayOwner< Scalar >                   m_pack_buf;
     size_t                                       m_owned_stride{}, m_shared_stride{};
     LocalIndex                                   m_max_owned{};
-    const unsigned                               m_id;
+    const int                                    m_id;
 };
 
 /// Performs import, i.e., data at shared indices is received from owning ranks

--- a/include/l3ster/comm/MpiComm.hpp
+++ b/include/l3ster/comm/MpiComm.hpp
@@ -48,12 +48,13 @@ L3STER_MPI_TYPE_MAPPING_STRUCT(long double, MPI_LONG_DOUBLE)               // NO
 L3STER_MPI_TYPE_MAPPING_STRUCT(std::byte, MPI_BYTE)                        // NOLINT
 
 inline void
-handleMPIError(int error, std::string_view err_msg, std::source_location src_loc = std::source_location::current())
+handleMPIError(int error, std::string_view fun_name, std::source_location src_loc = std::source_location::current())
 {
+    const auto err_msg = std::format("MPI error: call to {} failed with error code {}", fun_name, error);
     util::throwingAssert(not error, err_msg, src_loc);
 }
 
-#define L3STER_INVOKE_MPI(fun__, ...) comm::handleMPIError(fun__(__VA_ARGS__), "Call to " #fun__ " failed")
+#define L3STER_INVOKE_MPI(fun__, ...) comm::handleMPIError(fun__(__VA_ARGS__), #fun__)
 
 template < typename T >
 concept MpiBuiltinType_c = requires { MpiType< std::remove_cvref_t< T > >::value(); };

--- a/include/l3ster/comm/MpiComm.hpp
+++ b/include/l3ster/comm/MpiComm.hpp
@@ -100,6 +100,18 @@ auto parseMpiBuf(Buffer&& buf)
             return parseMpiBuf(std::as_writable_bytes(std::span{buf}));
     }
 }
+
+inline int getMaxMpiTag()
+{
+    // Static local variable ensures delayed initialization - we need to be mindful of MPI_Init
+    static const int max_tag = std::invoke([] {
+        int  has_value{};
+        int* ptr{};
+        L3STER_INVOKE_MPI(MPI_Comm_get_attr, MPI_COMM_WORLD, MPI_TAG_UB, &ptr, &has_value);
+        return *ptr;
+    });
+    return max_tag;
+}
 } // namespace comm
 
 class MpiComm

--- a/include/l3ster/common/Structs.hpp
+++ b/include/l3ster/common/Structs.hpp
@@ -14,7 +14,7 @@ struct Point
     constexpr Point() = default;
     constexpr Point(const std::array< val_t, DIM >& coords_) : coords{coords_} {}
     template < std::same_as< val_t >... Coord >
-    constexpr explicit Point(Coord... coords_)
+    constexpr explicit(DIM == 1) Point(Coord... coords_)
         requires(sizeof...(Coord) == DIM)
         : coords{coords_...}
     {}

--- a/include/l3ster/l3ster.hpp
+++ b/include/l3ster/l3ster.hpp
@@ -6,7 +6,7 @@
 #include "l3ster/algsys/MakeAlgebraicSystem.hpp"
 #include "l3ster/comm/DistributeMesh.hpp"
 #include "l3ster/mesh/primitives/CubeMesh.hpp"
-#include "l3ster/mesh/primitives/SquareMesh.hpp"
+#include "l3ster/mesh/primitives/CylinderInChannel3D.hpp"
 #include "l3ster/post/NormL2.hpp"
 #include "l3ster/post/VtkExport.hpp"
 #include "l3ster/solve/Amesos2Solvers.hpp"

--- a/include/l3ster/mesh/LocalMeshView.hpp
+++ b/include/l3ster/mesh/LocalMeshView.hpp
@@ -359,8 +359,12 @@ void reorderByAdjacency(std::vector< LocalElementView< ET, EO > >& elements, Nod
     auto       hot_elems          = robin_hood::unordered_flat_map< el_loc_id_t, NodeCacheHotnessModel::hotness_t >{};
     const auto populate_hot_elems = [&] {
         for (const auto& [node, hotness] : cache.getActiveNodes())
+        {
+            if (node >= nodes_to_elems.getNRows()) // Nodes not from the current domain may be present in the cache
+                continue;
             for (auto elem : nodes_to_elems(node) | std::views::filter([&](auto e) { return not done_elems.test(e); }))
                 hot_elems[elem] += hotness;
+        }
     };
     constexpr auto max_unsigned   = std::numeric_limits< unsigned >::max();
     const auto     get_el_connect = [&](el_loc_id_t el) -> unsigned {

--- a/include/l3ster/mesh/primitives/CylinderInChannel2D.hpp
+++ b/include/l3ster/mesh/primitives/CylinderInChannel2D.hpp
@@ -1,0 +1,140 @@
+#ifndef L3STER_MESH_CYLINDERINCHANNEL2D_HPP
+#define L3STER_MESH_CYLINDERINCHANNEL2D_HPP
+
+#include "l3ster/mesh/MeshUtils.hpp"
+#include "l3ster/mesh/primitives/SquareMesh.hpp"
+#include "l3ster/util/Common.hpp"
+
+namespace lstr::mesh
+{
+struct CylinderInChannel2DMeshIds
+{
+    d_id_t domain = 0, bottom = 1, top = 2, left = 3, right = 4, cylinder = 5;
+};
+
+struct CylinderInChannel2DGeometry
+{
+    val_t  r_inner = .5, r_outer = 2., left_offset = 10., right_offset = 16., bottom_offset = 15., top_offset = 15.;
+    size_t n_circumf = 64, n_radial = 19, n_left = 8, n_right = 50, n_bottom = 15, n_top = 15;
+    val_t  q_radial = 1.135, q_left = 1.3, q_right = 1.01, q_bottom = 1.2, q_top = 1.2;
+
+    [[nodiscard]] bool correct() const
+    {
+        const auto geom_correct =
+            r_inner < r_outer and std::min({left_offset, right_offset, bottom_offset, top_offset}) > r_outer;
+        const auto discr_correct =
+            n_circumf % 8 == 0 and std::min({n_circumf, n_radial, n_left, n_right, n_bottom, n_top}) > 0;
+        const auto q_correct = std::min({q_radial, q_left, q_right, q_bottom, q_top}) > 0.;
+        return geom_correct and discr_correct and q_correct;
+    }
+};
+
+inline auto makeCylinderInChannel2DMesh(const CylinderInChannel2DGeometry& geometry = {},
+                                        const CylinderInChannel2DMeshIds&  ids      = {}) -> MeshPartition< 1 >
+{
+    util::throwingAssert(geometry.correct());
+
+    using std::numbers::pi;
+    constexpr auto rotate = [](Point< 3 > p, val_t angle) -> Point< 3 > {
+        const auto s = std::sin(angle);
+        const auto c = std::cos(angle);
+        return {c * p.x() - s * p.y(), s * p.x() + c * p.y(), 0.};
+    };
+
+    const auto make_cylinder = [&] {
+        const auto radial_dist =
+            util::geomSpaceProg(geometry.r_inner, geometry.r_outer, geometry.n_radial + 1, geometry.q_radial);
+        const auto circumf_dist = util::linspace(0., 1., geometry.n_circumf / 2 + 1);
+        auto       top_half = makeSquareMesh(radial_dist, circumf_dist, {.domain = ids.domain, .left = ids.cylinder});
+        const auto deform_half = [&](Point< 3 > p) -> Point< 3 > {
+            const auto r     = p.x();
+            const auto angle = p.y() * pi;
+            return {r * std::cos(angle), r * std::sin(angle), 0.};
+        };
+        deform(top_half, deform_half);
+        auto bot_half = copy(top_half);
+        deform(bot_half, std::bind_back(rotate, pi));
+        return merge(top_half, bot_half);
+    };
+    auto cylinder = make_cylinder();
+
+    const auto make_wake = [&](val_t L, size_t n, val_t q, d_id_t edge_id) {
+        const auto x_dist = util::geomSpaceProg(0., L, n + 1, q);
+        const auto y_dist = util::linspace(-pi / 4., pi / 4., geometry.n_circumf / 4 + 1);
+        auto       retval = makeSquareMesh(x_dist, y_dist, {.domain = ids.domain, .right = edge_id});
+        deform(retval, [&](Point< 3 > p) -> Point< 3 > {
+            const auto x = p.x() + (1. - p.x() / L) * geometry.r_outer * std::cos(p.y());
+            const auto y = geometry.r_outer * std::sin(p.y());
+            return {x, y, 0.};
+        });
+        return retval;
+    };
+
+    const auto make_corner = [&](val_t Lx, size_t nx, val_t qx, val_t Ly, size_t ny, val_t qy, d_id_t rid, d_id_t tid) {
+        const auto sqr22 = std::sqrt(2.) / 2.;
+        return makeSquareMesh(util::geomSpaceProg(0., Lx, nx + 1, qx) | std::views::transform([&](val_t x) {
+                                  return x + (1. - x / Lx) * geometry.r_outer * sqr22;
+                              }),
+                              util::geomSpaceProg(0., Ly, ny + 1, qy) | std::views::transform([&](val_t y) {
+                                  return y + (1. - y / Ly) * geometry.r_outer * sqr22;
+                              }),
+                              {.domain = ids.domain, .top = tid, .right = rid});
+    };
+
+    auto right_wake = make_wake(geometry.right_offset, geometry.n_right, geometry.q_right, ids.right);
+    auto left_wake  = make_wake(geometry.left_offset, geometry.n_left, geometry.q_left, ids.left);
+    auto bot_wake   = make_wake(geometry.bottom_offset, geometry.n_bottom, geometry.q_bottom, ids.bottom);
+    auto top_wake   = make_wake(geometry.top_offset, geometry.n_top, geometry.q_top, ids.top);
+    deform(top_wake, std::bind_back(rotate, pi / 2.));
+    deform(left_wake, std::bind_back(rotate, pi));
+    deform(bot_wake, std::bind_back(rotate, 1.5 * pi));
+
+    auto tr_corner = make_corner(geometry.right_offset,
+                                 geometry.n_right,
+                                 geometry.q_right,
+                                 geometry.top_offset,
+                                 geometry.n_top,
+                                 geometry.q_top,
+                                 ids.right,
+                                 ids.top);
+    auto tl_corner = make_corner(geometry.top_offset,
+                                 geometry.n_top,
+                                 geometry.q_top,
+                                 geometry.left_offset,
+                                 geometry.n_left,
+                                 geometry.q_left,
+                                 ids.top,
+                                 ids.left);
+    auto bl_corner = make_corner(geometry.left_offset,
+                                 geometry.n_left,
+                                 geometry.q_left,
+                                 geometry.bottom_offset,
+                                 geometry.n_bottom,
+                                 geometry.q_bottom,
+                                 ids.left,
+                                 ids.bottom);
+    auto br_corner = make_corner(geometry.bottom_offset,
+                                 geometry.n_bottom,
+                                 geometry.q_bottom,
+                                 geometry.right_offset,
+                                 geometry.n_right,
+                                 geometry.q_right,
+                                 ids.bottom,
+                                 ids.right);
+    deform(tl_corner, std::bind_back(rotate, pi / 2.));
+    deform(bl_corner, std::bind_back(rotate, pi));
+    deform(br_corner, std::bind_back(rotate, 1.5 * pi));
+
+    cylinder = merge(cylinder, right_wake);
+    cylinder = merge(cylinder, left_wake);
+    cylinder = merge(cylinder, bot_wake);
+    cylinder = merge(cylinder, top_wake);
+    cylinder = merge(cylinder, tr_corner);
+    cylinder = merge(cylinder, tl_corner);
+    cylinder = merge(cylinder, bl_corner);
+    cylinder = merge(cylinder, br_corner);
+
+    return cylinder;
+}
+} // namespace lstr::mesh
+#endif // L3STER_MESH_CYLINDERINCHANNEL2D_HPP

--- a/include/l3ster/mesh/primitives/CylinderInChannel3D.hpp
+++ b/include/l3ster/mesh/primitives/CylinderInChannel3D.hpp
@@ -1,0 +1,21 @@
+#ifndef L3STER_MESH_CYLINDERINCHANNEL3D_HPP
+#define L3STER_MESH_CYLINDERINCHANNEL3D_HPP
+
+#include "l3ster/mesh/MeshUtils.hpp"
+#include "l3ster/mesh/primitives/CylinderInChannel2D.hpp"
+
+namespace lstr::mesh
+{
+template < std::ranges::random_access_range R >
+auto makeCylinderInChannel3DMesh(R&&                                zdist,
+                                 const CylinderInChannel2DGeometry& geometry = {},
+                                 const CylinderInChannel2DMeshIds&  ids      = {},
+                                 d_id_t                             id_back  = 6,
+                                 d_id_t                             id_front = 7) -> MeshPartition< 1 >
+    requires std::convertible_to< std::ranges::range_value_t< std::decay_t< R > >, val_t >
+{
+    const auto mesh2d = makeCylinderInChannel2DMesh(geometry, ids);
+    return extrude(mesh2d, std::forward< R >(zdist), id_back, id_front);
+}
+} // namespace lstr::mesh
+#endif // L3STER_MESH_CYLINDERINCHANNEL3D_HPP

--- a/include/l3ster/mesh/primitives/HalfCylinderInChannel2D.hpp
+++ b/include/l3ster/mesh/primitives/HalfCylinderInChannel2D.hpp
@@ -1,0 +1,135 @@
+#ifndef L3STER_MESH_HALFCYLINDERINCHANNEL2D_HPP
+#define L3STER_MESH_HALFCYLINDERINCHANNEL2D_HPP
+
+#include "l3ster/mesh/MeshUtils.hpp"
+#include "l3ster/mesh/primitives/SquareMesh.hpp"
+#include "l3ster/util/Common.hpp"
+
+namespace lstr::mesh
+{
+struct HalfCylinderInChannel2DMeshIds
+{
+    d_id_t domain = 0, bottom_left = 1, cylinder = 2, bottom_right = 3, top = 4, left = 5, right = 6;
+};
+
+struct HalfCylinderInChannel2DGeometry
+{
+    val_t  r_inner = .5, r_outer = 2., left_offset = 10., right_offset = 16., top_offset = 15.;
+    size_t n_circumf = 64, n_radial = 19, n_left = 8, n_right = 50, n_top = 15;
+    val_t  q_radial = 1.135, q_left = 1.3, q_right = 1.01, q_top = 1.2;
+
+    [[nodiscard]] bool correct() const
+    {
+        const auto geom_correct  = r_inner < r_outer and std::min({left_offset, right_offset, top_offset}) > r_outer;
+        const auto discr_correct = n_circumf % 8 == 0 and std::min({n_circumf, n_radial, n_left, n_right, n_top}) > 0;
+        const auto q_correct     = std::min({q_radial, q_left, q_right, q_top}) > 0.;
+        return geom_correct and discr_correct and q_correct;
+    }
+};
+
+inline auto makeHalfCylinderInChannel2DMesh(const HalfCylinderInChannel2DGeometry& geometry = {},
+                                            const HalfCylinderInChannel2DMeshIds&  ids      = {}) -> MeshPartition< 1 >
+{
+    util::throwingAssert(geometry.correct());
+
+    using std::numbers::pi;
+    constexpr auto rotate = [](Point< 3 > p, val_t angle) -> Point< 3 > {
+        const auto s = std::sin(angle);
+        const auto c = std::cos(angle);
+        return {c * p.x() - s * p.y(), s * p.x() + c * p.y(), 0.};
+    };
+
+    const auto make_cylinder = [&] {
+        const auto radial_dist =
+            util::geomSpaceProg(geometry.r_inner, geometry.r_outer, geometry.n_radial + 1, geometry.q_radial);
+        const auto circumf_dist = util::linspace(0., 1., geometry.n_circumf / 2 + 1);
+        auto       top_half     = makeSquareMesh(
+            radial_dist,
+            circumf_dist,
+            {.domain = ids.domain, .bottom = ids.bottom_right, .top = ids.bottom_left, .left = ids.cylinder});
+        const auto deform_half = [&](Point< 3 > p) -> Point< 3 > {
+            const auto r     = p.x();
+            const auto angle = p.y() * pi;
+            return {r * std::cos(angle), r * std::sin(angle), 0.};
+        };
+        deform(top_half, deform_half);
+        return top_half;
+    };
+    auto cylinder = make_cylinder();
+
+    const auto make_wake = [&](val_t L, size_t n, val_t q, d_id_t edge_id) {
+        const auto x_dist = util::geomSpaceProg(0., L, n + 1, q);
+        const auto y_dist = util::linspace(-pi / 4., pi / 4., geometry.n_circumf / 4 + 1);
+        auto       retval = makeSquareMesh(x_dist, y_dist, {.domain = ids.domain, .right = edge_id});
+        deform(retval, [&](Point< 3 > p) -> Point< 3 > {
+            const auto x = p.x() + (1. - p.x() / L) * geometry.r_outer * std::cos(p.y());
+            const auto y = geometry.r_outer * std::sin(p.y());
+            return {x, y, 0.};
+        });
+        return retval;
+    };
+    const auto make_half_wake =
+        [&](val_t L, size_t n, val_t q, d_id_t edge_id, d_id_t in_id, bool generate_right = true) {
+            const val_t lo     = generate_right ? 0. : -pi / 4.;
+            const val_t hi     = generate_right ? pi / 4. : 0.;
+            const auto  x_dist = util::geomSpaceProg(0., L, n + 1, q);
+            const auto  y_dist = util::linspace(lo, hi, geometry.n_circumf / 8 + 1);
+            auto        retval =
+                makeSquareMesh(x_dist, y_dist, {.domain = ids.domain, .bottom = in_id, .top = in_id, .right = edge_id});
+            deform(retval, [&](Point< 3 > p) -> Point< 3 > {
+                const auto x = p.x() + (1. - p.x() / L) * geometry.r_outer * std::cos(p.y());
+                const auto y = geometry.r_outer * std::sin(p.y());
+                return {x, y, 0.};
+            });
+            return retval;
+        };
+
+    const auto make_corner =
+        [&](val_t Lx, size_t nx, val_t qx, val_t Ly, size_t ny, val_t qy, d_id_t rid, d_id_t tid, d_id_t other_id) {
+            const auto sqr22 = std::sqrt(2.) / 2.;
+            return makeSquareMesh(
+                util::geomSpaceProg(0., Lx, nx + 1, qx) |
+                    std::views::transform([&](val_t x) { return x + (1. - x / Lx) * geometry.r_outer * sqr22; }),
+                util::geomSpaceProg(0., Ly, ny + 1, qy) |
+                    std::views::transform([&](val_t y) { return y + (1. - y / Ly) * geometry.r_outer * sqr22; }),
+                {.domain = ids.domain, .bottom = other_id, .top = tid, .left = other_id, .right = rid});
+        };
+
+    auto right_wake =
+        make_half_wake(geometry.right_offset, geometry.n_right, geometry.q_right, ids.right, ids.bottom_right);
+    auto left_wake =
+        make_half_wake(geometry.left_offset, geometry.n_left, geometry.q_left, ids.left, ids.bottom_left, false);
+    auto top_wake = make_wake(geometry.top_offset, geometry.n_top, geometry.q_top, ids.top);
+    deform(top_wake, std::bind_back(rotate, pi / 2.));
+    deform(left_wake, std::bind_back(rotate, pi));
+
+    auto tr_corner = make_corner(geometry.right_offset,
+                                 geometry.n_right,
+                                 geometry.q_right,
+                                 geometry.top_offset,
+                                 geometry.n_top,
+                                 geometry.q_top,
+                                 ids.right,
+                                 ids.top,
+                                 ids.bottom_right);
+    auto tl_corner = make_corner(geometry.top_offset,
+                                 geometry.n_top,
+                                 geometry.q_top,
+                                 geometry.left_offset,
+                                 geometry.n_left,
+                                 geometry.q_left,
+                                 ids.top,
+                                 ids.left,
+                                 ids.bottom_left);
+    deform(tl_corner, std::bind_back(rotate, pi / 2.));
+
+    cylinder = merge(cylinder, right_wake);
+    cylinder = merge(cylinder, left_wake);
+    cylinder = merge(cylinder, top_wake);
+    cylinder = merge(cylinder, tr_corner);
+    cylinder = merge(cylinder, tl_corner);
+
+    return cylinder;
+}
+} // namespace lstr::mesh
+#endif // L3STER_MESH_HALFCYLINDERINCHANNEL2D_HPP

--- a/include/l3ster/util/EigenUtils.hpp
+++ b/include/l3ster/util/EigenUtils.hpp
@@ -51,6 +51,9 @@ template < std::floating_point T, int RCMaj = Eigen::RowMajor >
 using DynamicallySizedMatrix =
     Eigen::Matrix< T, Eigen::Dynamic, Eigen::Dynamic, RCMaj, Eigen::Dynamic, Eigen::Dynamic >;
 
+template < std::floating_point T, int rows, int cols, int RCMaj = Eigen::ColMajor >
+using MatrixMaxCol_t = Eigen::Matrix< T, rows, Eigen::Dynamic, RCMaj, rows, cols >;
+
 template < typename T >
 concept StaticallySizedMatrix_c = Matrix_c< T > and detail::is_statically_sized_martix< T >;
 } // namespace lstr::util::eigen

--- a/tests/MpiImportExportTest.cpp
+++ b/tests/MpiImportExportTest.cpp
@@ -99,8 +99,16 @@ int main(int argc, char* argv[])
 
     const auto ownership = util::SegmentedOwnership{first_ind, owned_inds.size(), shared_inds};
     auto       context   = std::make_shared< const ImportExportContext >(comm, ownership);
-    auto       importer  = Import< Scalar >{context, mv_cols};
-    auto       exporter  = Export< Scalar >{std::move(context), mv_cols};
+    auto       importer  = Import< Scalar >{context, 2 * mv_cols};
+    auto       exporter  = Export< Scalar >{std::move(context), 2 * mv_cols};
+    REQUIRE(importer.getNumVecs() == 2 * mv_cols);
+    REQUIRE(exporter.getNumVecs() == 2 * mv_cols);
+    importer.setNumVecs(mv_cols);
+    exporter.setNumVecs(mv_cols);
+    REQUIRE(importer.getNumVecs() == mv_cols);
+    REQUIRE(exporter.getNumVecs() == mv_cols);
+    CHECK_THROWS(importer.setNumVecs(3 * mv_cols));
+    CHECK_THROWS(exporter.setNumVecs(3 * mv_cols));
     importer.setOwned(x, all_inds_sz);
     importer.setShared(std::span{x}.subspan(owned_inds.size()), all_inds_sz);
     exporter.setOwned(y, all_inds_sz);

--- a/tests/SumFactorizationTests.cpp
+++ b/tests/SumFactorizationTests.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Sum-factorized evaluation", "[local_asm]")
         const auto local_element = mesh::LocalElementView{element, global_mesh, {}};
         const auto sol_man       = makeRandomlyFilledSolutiondManager(global_mesh, 1);
 
-        auto x = Operand< ET, EO, params >{};
+        auto x = Operand< ET, EO, params >{operand_size< ET, EO, params >, params.n_rhs};
         x.setRandom();
 
         const auto y_local_element = evalDiffusionOperator2DVar< params >(local_element, x, sol_man);
@@ -41,7 +41,7 @@ TEST_CASE("Sum-factorized evaluation", "[local_asm]")
         const auto local_element = mesh::LocalElementView{element, global_mesh, {}};
         const auto sol_man       = makeRandomlyFilledSolutiondManager(global_mesh, 1);
 
-        auto x = Operand< ET, EO, params >{};
+        auto x = Operand< ET, EO, params >{operand_size< ET, EO, params >, params.n_rhs};
         x.setRandom();
 
         const auto y_local_element = evalDiffusionOperator3DVar< params >(local_element, x, sol_man);


### PR DESCRIPTION
- Matrix free operators can now operate on multi-RHS problems
- Fixed bug in interior/border mesh generation
- Changed import/export tag behavior to support environments with lower values of `MPI_TAG_UB`